### PR TITLE
Remove single quotes in powershell task

### DIFF
--- a/Tasks/powershell/Run-Command.ps1
+++ b/Tasks/powershell/Run-Command.ps1
@@ -24,7 +24,7 @@ if ($WorkingDirectory -and $WorkingDirectory -ne "") {
 # Note that this will run powershell.exe
 # even if the system has pwsh.exe.
 Write-Output "Running command $Command"
-powershell.exe -Command '$Command'
+powershell.exe -Command $Command
 $CommandExitCode = $LASTEXITCODE
 Write-Output "Command exited with code $CommandExitCode"
 


### PR DESCRIPTION
Since we are adding single quotes around task input, I'm removing the quotes around the command parameter in this PowerShell task so it can run properly.