### PR TITLE
Adding a task for populating the VS solution cache.

### DIFF
--- a/Tasks/populate-vs-solution-cache/main.ps1
+++ b/Tasks/populate-vs-solution-cache/main.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Invokes the PopulateSolutionCache command of Visual Studio's devenv.exe.
+.DESCRIPTION
+    The PopulateSolutionCache command generates caches for the specified solution file. The resulting caches
+    can improve the performance of various Visual Studio features in a first-run scenario.
+.PARAMETER SolutionFilePath
+    Required - The path to the .sln file for which caches should be generated.
+.PARAMETER Build
+    Optional. Default false. A switch indicating whether to run build as part of the populateSolutionCache process.
+    This is useful as it allows the fast up to date check cache to be generated, which can improve F5
+    performance. The drawback is that running the build causes populateSolutionCache to take longer
+    to complete.
+.PARAMETER NotLocalCache
+    Optional. Default false. A switch indicating that the generated caches should be generalized such that they
+    can be moved between machine (as opposed to being used on the same machine on which the populateSolutionCache
+    command was run).
+.PARAMETER SolnConfigName
+    Optional. Only used in combination with the Build switch. The name of the solution configuration (such as Debug
+    or Release) to be used to build the solution. If multiple solution platforms are available, you must also specify
+    the platform (for example, Debug|Win32). If this argument is unspecified or an empty string (""), the tool uses
+    the solution's active configuration.
+.PARAMETER ProjectName
+    Optional. Only used in combination with the Build switch. The path and name of a project file within the solution.
+    You can enter a relative path from the solution file's folder to the project file, or the project's display name,
+    or the full path and name of the project file.
+.PARAMETER ProjConfigName
+    Optional. Only used in combination with the ProjectName parameter. The name of a project build configuration (such as
+    Debug or Release) to be used when building the named project. If more than one solution platform is available,
+    you must also specify the platform (for example, Debug|Win32). If this switch is specified, it overrides the
+    SolnConfigName argument.
+.PARAMETER VSWherePath
+    Optional. If the Visual Studio Installer is located in a non-default location you can use this VSWherePath to
+    specify the full path to the vswhere.exe utility.
+#>
+param (
+        [Parameter()]
+        [string]$SolutionFilePath,
+
+        [Parameter()]
+        [string]$Build,
+
+        [Parameter()]
+        [switch]$NotLocalCache,
+
+        [Parameter()]
+        [string]$SolnConfigName,
+
+        [Parameter()]
+        [string]$ProjectName,
+
+        [Parameter()]
+        [string]$ProjConfigName,
+
+        [Parameter()]
+        [string]$VSWherePath
+    )
+
+if (![System.IO.File]::Exists($SolutionFilePath)) {
+    Write-Host "File not found: $SolutionFilePath"
+    return;
+}
+
+if ([System.String]::IsNullOrWhiteSpace($VSWherePath)) {
+    $VSWherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" 
+}
+$vswhereArgs = "-latest", "-requires", "Microsoft.Component.MSBuild", "-find", "Common7\IDE\devenv.com"
+
+if (![System.IO.File]::Exists($VSWherePath)) {
+    Write-Host "Unable to locate vswhere.exe at '$VSWherePath'. Please provide the correct path using the VSWherePath parameter."
+    return;
+}
+else {
+    $devenvPath = & $vswherePath $vswhereArgs
+
+    $devenvArgs = $SolutionFilePath, "/populateSolutionCache"
+    
+    if (!$NotLocalCache) {
+        $devenvArgs += "/localCache"
+    }
+
+    if ($Build -eq "true") {
+        $devenvArgs += "/build"
+
+        if (![System.String]::IsNullOrWhiteSpace($SolnConfigName)) {
+            $devenvArgs += $SolnConfigName
+        }
+
+        if (![System.String]::IsNullOrWhiteSpace($ProjectName)) {
+            $devenvArgs += "/project"
+            $devenvArgs += $ProjectName
+
+            if (![System.String]::IsNullOrWhiteSpace($ProjConfigName)) {
+                $devenvArgs += "/projectconfig"
+                $devenvArgs += $ProjConfigName
+            }
+        }
+    }
+
+    Write-Host $devenvPath $devenvArgs
+    & $devenvPath $devenvArgs
+}

--- a/Tasks/populate-vs-solution-cache/task.yaml
+++ b/Tasks/populate-vs-solution-cache/task.yaml
@@ -1,0 +1,41 @@
+name: populate-vs-solution-cache
+description: Populate the Visual Studio solution cache. The resulting caches can improve the performance of various Visual Studio features in a first-run scenario.
+command: ./main.ps1 -solutionFilePath {{ solutionFilePath }} -build {{ build }} -notLocalCache {{ notLocalCache }} -solnConfigName {{ solnConfigName }} -projectName {{ projectName }} -projConfigName {{ projConfigName }} -vsWherePath {{ vsWherePath }}
+
+inputs:
+  solutionFilePath:
+    type: string
+    required: true
+    description: The path to the .sln file for which caches should be generated.
+  build:
+    type: boolean
+    required: false
+    default: false
+    description: Indicates whether to run build as part of the populateSolutionCache process. This is useful as it allows the fast up to date check cache to be generated, which can improve F5 performance. The drawback is that running the build causes populateSolutionCache to take longer to complete.
+  notLocalCache:
+    type: boolean
+    required: false
+    default: false
+    description: Indicates that the generated caches should be generalized such that they can be moved between machine (as opposed to being used on the same machine on which the populateSolutionCache command was run).
+  solnConfigName:
+    type: string
+    required: false
+    default: ''
+    description: The name of the solution configuration (such as Debug or Release) to be used to build the solution. If multiple solution platforms are available, you must also specify the platform (for example, Debug|Win32). If this argument is unspecified or an empty string (""), the tool uses the solution's active configuration.
+  projectName:
+    type: string
+    required: false
+    default: ''
+    description: The path and name of a project file within the solution. You can enter a relative path from the solution file's folder to the project file, or the project's display name, or the full path and name of the project file.
+  projConfigName:
+    type: string
+    required: false
+    default: ''
+    description: The name of a project build configuration (such as Debug or Release) to be used when building the named project. If more than one solution platform is available, you must also specify the platform (for example, Debug|Win32). If this switch is specified, it overrides the SolnConfigName argument.
+  vsWherePath:
+    type: string
+    required: false
+    default: ''
+    description: If the Visual Studio Installer is located in a non-default location you can use this VSWherePath to specify the full path to the vswhere.exe utility.
+
+


### PR DESCRIPTION
This pull request adds a new task to the project called `populate-vs-solution-cache`, which generates caches for a specified solution file to improve the performance of various Visual Studio features in a first-run scenario. The task is implemented with a PowerShell script that invokes the `PopulateSolutionCache` command of Visual Studio's `devenv.exe` with several input parameters and error handling.

The main PowerShell script comes from the VS team who worked on the VS caching functionality. You can learn more about the underlying capability at https://learn.microsoft.com/en-us/azure/dev-box/how-to-generate-visual-studio-caches.