### PR TITLE
[Security] Add Security Linter Devskim

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: DevSkim
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    name: DevSkim
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: devskim-results.sarif


### PR DESCRIPTION
Adding this step to the workflow will help catch bad practices on new code changes for our powershell scripts. It will create a comment on the PR for the reviewer to validate before merging. 

Devskim is an open-source repo owned by Microsoft: https://github.com/microsoft/DevSkim
ex:

![image](https://github.com/microsoft/devcenter-catalog/assets/23067852/c1138727-038f-46ea-b063-86fbcf4b2c5a)
