### PR TITLE
Add update WinGet

### DIFF
--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -167,6 +167,20 @@ function InstallWinGet {
         Write-Host "Microsoft.WinGet.Configuration is already installed"
     }
 
+    # if scope is CurrentUser, we need to update WinGet
+    if ($psInstallScope -eq "CurrentUser") {
+        Write-Host "Updating WinGet"
+
+        try {
+            Repair-WinGetPackageManager -Latest -Force
+            Write-Host "Done Updating WinGet"
+        }
+        catch {
+            Write-Error "Failed to update WinGet"
+            Write-Error $_
+        }
+    }
+
     # if scope is CurrentUser, we need to ensure AppInstaller is installed
     if ($psInstallScope -eq "CurrentUser") {
         # we're not running as system, so install Microsoft.DesktopAppInstaller


### PR DESCRIPTION
Adding update WinGet command to the WinGet script to fix an error where some images use an older version of WinGet and cannot connect to the package feed. 