### PR TITLE
Updates environment variables for AZD compatible templates

### DIFF
--- a/Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json
+++ b/Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json
@@ -650,8 +650,8 @@
           },
           "appSettings": {
             "value": {
-              "REACT_APP_API_BASE_URL": "[if(parameters('useAPIM'), reference(resourceId('Microsoft.Resources/deployments', 'apim-api-deployment'), '2022-09-01').outputs.SERVICE_API_URI.value, reference(resourceId('Microsoft.Resources/deployments', 'api'), '2022-09-01').outputs.SERVICE_API_URI.value)]",
-              "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
+              "API_BASE_URL": "[if(parameters('useAPIM'), reference(resourceId('Microsoft.Resources/deployments', 'apim-api-deployment'), '2022-09-01').outputs.SERVICE_API_URI.value, reference(resourceId('Microsoft.Resources/deployments', 'api'), '2022-09-01').outputs.SERVICE_API_URI.value)]",
+              "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
             }
           }
         },
@@ -3723,13 +3723,9 @@
       "type": "string",
       "value": "[tenant().tenantId]"
     },
-    "REACT_APP_API_BASE_URL": {
+    "API_BASE_URL": {
       "type": "string",
       "value": "[if(parameters('useAPIM'), reference(resourceId('Microsoft.Resources/deployments', 'apim-api-deployment'), '2022-09-01').outputs.SERVICE_API_URI.value, reference(resourceId('Microsoft.Resources/deployments', 'api'), '2022-09-01').outputs.SERVICE_API_URI.value)]"
-    },
-    "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
     },
     "REACT_APP_WEB_BASE_URL": {
       "type": "string",

--- a/Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json
+++ b/Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json
@@ -754,11 +754,11 @@
                   "env": {
                     "value": [
                       {
-                        "name": "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING",
+                        "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
                         "value": "[reference(resourceId('Microsoft.Insights/components', parameters('applicationInsightsName')), '2020-02-02').ConnectionString]"
                       },
                       {
-                        "name": "REACT_APP_API_BASE_URL",
+                        "name": "API_BASE_URL",
                         "value": "[parameters('apiBaseUrl')]"
                       },
                       {
@@ -4655,13 +4655,9 @@
       "type": "string",
       "value": "[tenant().tenantId]"
     },
-    "REACT_APP_API_BASE_URL": {
+    "API_BASE_URL": {
       "type": "string",
       "value": "[if(parameters('useAPIM'), reference(resourceId('Microsoft.Resources/deployments', 'apim-api-deployment'), '2022-09-01').outputs.SERVICE_API_URI.value, reference(resourceId('Microsoft.Resources/deployments', 'api'), '2022-09-01').outputs.SERVICE_API_URI.value)]"
-    },
-    "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
     },
     "REACT_APP_WEB_BASE_URL": {
       "type": "string",

--- a/Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json
+++ b/Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json
@@ -3806,13 +3806,9 @@
       "type": "string",
       "value": "[tenant().tenantId]"
     },
-    "REACT_APP_API_BASE_URL": {
+    "API_BASE_URL": {
       "type": "string",
       "value": "[if(parameters('useAPIM'), reference(resourceId('Microsoft.Resources/deployments', 'apim-api-deployment'), '2022-09-01').outputs.SERVICE_API_URI.value, reference(resourceId('Microsoft.Resources/deployments', 'api'), '2022-09-01').outputs.SERVICE_API_URI.value)]"
-    },
-    "REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
     },
     "REACT_APP_WEB_BASE_URL": {
       "type": "string",


### PR DESCRIPTION
The Todo suite of `azd` templates recently migrated from using CreateReactApp (CRA) to VITE. 

This change updates the underlying ADE environment definitions to work correctly with the app code changes.