### PR TITLE
Add support for version parameter to winget task

### DIFF
--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -332,6 +332,7 @@ else {
 
         # If there's a version passed, update the version parameter
         if ($Version -ne '') {
+            Write-Host "Specifying version: $($Version)"
             $Version = "-Version $Version"
         }
         

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -8,6 +8,8 @@ param (
     [Parameter()]
     [string]$Package,
     [Parameter()]
+    [string]$Version = '',
+    [Parameter()]
     [string]$RunAsUser
 )
 
@@ -327,8 +329,13 @@ else {
     # We're running in package mode:
     if ($Package) {
         Write-Host "Running package install: $($Package)"
+
+        # If there's a version passed, update the version parameter
+        if ($Version -ne '') {
+            $Version = "-Version $Version"
+        }
         
-        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
+        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($Version) | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -288,6 +288,13 @@ elseif ($DownloadUrl) {
     Write-Host "Downloaded configuration to: $($ConfigurationFile)"
 }
 
+$versionFlag = ""
+# If there's a version passed, add the version flag
+if ($Version -ne '') {
+    Write-Host "Specifying version: $($Version)"
+    $versionFlag = "-Version"
+}
+
 # We're running as user via scheduled task:
 if ($RunAsUser -eq "true") {
     Write-Host "Running as user via scheduled task"
@@ -301,7 +308,7 @@ if ($RunAsUser -eq "true") {
     # We're running in package mode:
     if ($Package) {
         Write-Host "Appending package install: $($Package)"
-        AppendToUserScript "winget install --id `"$($Package)`" --accept-source-agreements --accept-package-agreements"
+        AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) `"$($Version)`" --accept-source-agreements --accept-package-agreements"
         AppendToUserScript "Write-Host `"winget exit code: `$LASTEXITCODE`""
     }
     # We're running in configuration file mode:
@@ -329,14 +336,7 @@ else {
     # We're running in package mode:
     if ($Package) {
         Write-Host "Running package install: $($Package)"
-
-        # If there's a version passed, update the version parameter
-        $versionFlag = ""
-        if ($Version -ne '') {
-            Write-Host "Specifying version: $($Version)"
-            $versionFlag = "-Version"
-        }
-        
+           
         $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($versionFlag) '$($Version)' | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -289,12 +289,6 @@ elseif ($DownloadUrl) {
 }
 
 $versionFlag = ""
-# If there's a version passed, add the version flag
-if ($Version -ne '') {
-    Write-Host "Specifying version: $($Version)"
-    $versionFlag = "-Version"
-}
-
 # We're running as user via scheduled task:
 if ($RunAsUser -eq "true") {
     Write-Host "Running as user via scheduled task"
@@ -307,6 +301,11 @@ if ($RunAsUser -eq "true") {
 
     # We're running in package mode:
     if ($Package) {
+        # If there's a version passed, add the version flag for CLI
+        if ($Version -ne '') {
+            Write-Host "Specifying version: $($Version)"
+            $versionFlag = "--version"
+        }
         Write-Host "Appending package install: $($Package)"
         AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) `"$($Version)`" --accept-source-agreements --accept-package-agreements"
         AppendToUserScript "Write-Host `"winget exit code: `$LASTEXITCODE`""
@@ -336,7 +335,13 @@ else {
     # We're running in package mode:
     if ($Package) {
         Write-Host "Running package install: $($Package)"
-           
+
+        # If there's a version passed, add the version flag for PS
+        if ($Version -ne '') {
+            Write-Host "Specifying version: $($Version)"
+            $versionFlag = "-Version"
+        }
+
         $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($versionFlag) '$($Version)' | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -331,12 +331,13 @@ else {
         Write-Host "Running package install: $($Package)"
 
         # If there's a version passed, update the version parameter
+        $versionFlag = ""
         if ($Version -ne '') {
             Write-Host "Specifying version: $($Version)"
-            $Version = "-Version $Version"
+            $versionFlag = "-Version"
         }
         
-        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($Version) | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
+        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($versionFlag) '$($Version)' | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()

--- a/Tasks/winget/task.yaml
+++ b/Tasks/winget/task.yaml
@@ -31,6 +31,13 @@ parameters:
     description: |
       The name of the package to install. This is an alternative way. 
       If a config yaml file is provided under other parameters, there is no need for the package name.
+  version:
+    default: ''
+    type: 'string'
+    required: false
+    description: |
+      The version of the package to install.
+      If a config yaml file is provided under other parameters, there is no need for the package version.
   runAsUser:
     default: false
     type: 'boolean'

--- a/Tasks/winget/task.yaml
+++ b/Tasks/winget/task.yaml
@@ -4,7 +4,7 @@ $schema: 1.0
 name: winget
 description: Applies a winget configuration to the Dev Box.
 author: Microsoft Corporation
-command: './main.ps1 -ConfigurationFile {{configurationFile}} -DownloadUrl {{downloadUrl}} -InlineConfigurationBase64 {{inlineConfigurationBase64}} -Package {{package}} -RunAsUser {{runAsUser}}'
+command: './main.ps1 -ConfigurationFile {{configurationFile}} -DownloadUrl {{downloadUrl}} -InlineConfigurationBase64 {{inlineConfigurationBase64}} -Package {{package}} -Version {{version}} -RunAsUser {{runAsUser}}'
 parameters:
   configurationFile:
     default: ''


### PR DESCRIPTION
This PR adds the "version" parameter for use in the winget task, allowing users to specify a version of the package to install.

This was tested by locally running the `main.ps1` script for the winget task with the following scenarios:
1. Passing `-package Microsoft.DotNet.Framework.DeveloperPack_4 -version 4.6.2` -- successfully installed .NET Framework 4.6.2
2. Passing `-package Microsoft.DotNet.Framework.DeveloperPack_4` -- successfully installed .NET Framework 4.8.1 (the default, since no version was provided)