### PR TITLE
Attempt to register winget COM components when running as user

### DIFF
--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -180,11 +180,12 @@ function InstallWinGet {
 
     Write-Host "Updating WinGet"
     try {
+        Write-Host "Attempting to repair WinGet Package Manager"
         Repair-WinGetPackageManager -Latest -Force
-        Write-Host "Done Updating WinGet"
+        Write-Host "Done Reparing WinGet Package Manager"
     }
     catch {
-        Write-Error "Failed to update WinGet"
+        Write-Host "Failed to repair WinGet Package Manager"
         Write-Error $_
     }
 
@@ -204,7 +205,7 @@ function InstallWinGet {
                 Add-AppxPackage -Path "$($MsUiXaml)\tools\AppX\$($architecture)\Release\Microsoft.UI.Xaml.2.8.appx" -ForceApplicationShutdown
                 Write-Host "Done Installing Microsoft.UI.Xaml"
             } catch {
-                Write-Error "Failed to install Microsoft.UI.Xaml"
+                Write-Host "Failed to install Microsoft.UI.Xaml"
                 Write-Error $_
             }
         }
@@ -220,12 +221,14 @@ function InstallWinGet {
                 Write-Host "Done Installing Microsoft.DesktopAppInstaller"
             }
             catch {
-                Write-Error "Failed to install DesktopAppInstaller appx package"
+                Write-Host "Failed to install DesktopAppInstaller appx package"
                 Write-Error $_
             }
         }
 
+        Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+        Write-Host "WinGet version: $(winget -v)"
     }
 
     # Revert PSGallery installation policy to untrusted

--- a/Tasks/winget/runAsUser.ps1
+++ b/Tasks/winget/runAsUser.ps1
@@ -68,7 +68,7 @@ if (!(Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8")){
         Add-AppxPackage -Path "$($MsUiXaml)\tools\AppX\$($architecture)\Release\Microsoft.UI.Xaml.2.8.appx" -ForceApplicationShutdown
         Write-Host "Done Installing Microsoft.UI.Xaml"
     } catch {
-        Write-Error "Failed to install Microsoft.UI.Xaml"
+        Write-Host "Failed to install Microsoft.UI.Xaml"
         Write-Error $_
     }
 }
@@ -87,7 +87,7 @@ if (!($desktopAppInstallerPackage) -or ($desktopAppInstallerPackage.Version -lt 
         Write-Host "Done Installing Microsoft.DesktopAppInstaller"
     }
     catch {
-        Write-Error "Failed to install DesktopAppInstaller appx package"
+        Write-Host "Failed to install DesktopAppInstaller appx package"
         Write-Error $_
     }
 }


### PR DESCRIPTION
This attempts to address an error when attempting to run winget configurations in the user context, as it can fail to instantiate a COM component with CLSID {526534B8-7E46-47C8-8416-B1685C327D37}.