### PR TITLE
Fix bug that prevents packages from installing when runAsUser=true

### DIFF
--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -309,10 +309,10 @@ if ($RunAsUser -eq "true") {
         # If there's a version passed, add the version flag for CLI
         if ($Version -ne '') {
             Write-Host "Specifying version: $($Version)"
-            $versionFlag = "--version"
+            $versionFlag = "--version `"$($Version)`""
         }
         Write-Host "Appending package install: $($Package)"
-        AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) `"$($Version)`" --accept-source-agreements --accept-package-agreements"
+        AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) --accept-source-agreements --accept-package-agreements"
         AppendToUserScript "Write-Host `"winget exit code: `$LASTEXITCODE`""
     }
     # We're running in configuration file mode:
@@ -343,10 +343,10 @@ else {
         # If there's a version passed, add the version flag for PS
         if ($Version -ne '') {
             Write-Host "Specifying version: $($Version)"
-            $versionFlag = "-Version"
+            $versionFlag = "-Version '$($Version)'"
         }
 
-        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($versionFlag) '$($Version)' | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
+        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"Install-WinGetPackage -Id '$($Package)' $($versionFlag) | ConvertTo-Json -Depth 10 > $($tempOutFile)`""}
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()


### PR DESCRIPTION
The bug's root cause was the addition of the Version parameter to enable specifying package versions. The implementation adds an empty string "" whenever the version isn't specified, and this empty string in the command line that calls winget.exe causes it to error out.

The fix is to clean the command line so it doesn't contain empty string "" when involking the task with an empty version parameter.