### PR TITLE
Roll back to using Invoke-CimMethod to spin up pwsh in winget scenarios

### DIFF
--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -273,7 +273,7 @@ if (!(Get-Command git -ErrorAction SilentlyContinue)) {
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
         if ($installExitCode -ne 0) {
-            Write-Error "Failed to install Git.Git with Install-WinGetPackage, error code $($installExitCode)"
+            Write-Error "Failed to install Git.Git with Install-WinGetPackage, error code $($installExitCode)."
             # this was the last try, so exit with the install exit code
             exit $installExitCode
         }
@@ -285,12 +285,12 @@ if (!(Get-Command git -ErrorAction SilentlyContinue)) {
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json
             if ($unitResultsObject.Status -ne "Ok") {
-                Write-Error "There were errors installing the Git.Git package"
+                Write-Error "There were errors installing the Git.Git package."
                 exit 1
             }
         }
         else {
-            Write-Host "Couldn't find output file for Git.Git installation, assuming fail"
+            Write-Host "Couldn't find output file for Git.Git installation, assuming fail."
             exit 1
         }
 
@@ -340,7 +340,7 @@ if (!(Get-Command git-lfs -ErrorAction SilentlyContinue)) {
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
         if ($installExitCode -ne 0) {
-            Write-Error "Failed to install git-lfs with Install-WinGetPackage, error code $($installExitCode)"
+            Write-Error "Failed to install git-lfs with Install-WinGetPackage, error code $($installExitCode)."
             # this was the last try, so exit with the install exit code
             exit $installExitCode
         }
@@ -352,12 +352,12 @@ if (!(Get-Command git-lfs -ErrorAction SilentlyContinue)) {
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json
             if ($unitResultsObject.Status -ne "Ok") {
-                Write-Error "There were errors installing the GitHub.GitLFS package"
+                Write-Error "There were errors installing the GitHub.GitLFS package."
                 exit 1
             }
         }
         else {
-            Write-Host "Couldn't find output file for GitHub.GitLFS installation, assuming fail"
+            Write-Host "Couldn't find output file for GitHub.GitLFS installation, assuming fail."
             exit 1
         }
 

--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -280,6 +280,7 @@ if (!(Get-Command git -ErrorAction SilentlyContinue)) {
         # read the output file and write it to the console
         if (Test-Path -Path $tempOutFile) {
             $unitResults = Get-Content -Path $tempOutFile -Raw | Out-String
+            Write-Host $unitResults
             Remove-Item -Path $tempOutFile -Force
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json
@@ -346,6 +347,7 @@ if (!(Get-Command git-lfs -ErrorAction SilentlyContinue)) {
         # read the output file and write it to the console
         if (Test-Path -Path $tempOutFile) {
             $unitResults = Get-Content -Path $tempOutFile -Raw | Out-String
+            Write-Host $unitResults
             Remove-Item -Path $tempOutFile -Force
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json

--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -261,14 +261,13 @@ if (!(Get-Command git -ErrorAction SilentlyContinue)) {
 
         $tempOutFile = [System.IO.Path]::GetTempFileName() + ".out.json"
         $installGitCommand = "Install-WinGetPackage -Source winget -Id Git.Git | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
-        $processOptions = @{
-            FilePath = "C:\Program Files\PowerShell\7\pwsh.exe"
-            ArgumentList = "$($mtaFlag) -Command `"$($installGitCommand)`""
-            PassThru = $true
-            NoNewWindow = $true
-            WorkingDirectory = $env:TEMP
+        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"$($installGitCommand)`""}
+        if (!($processCreation) -or !($processCreation.ProcessId)) {
+            Write-Error "Failed to install Git.Git package. Process creation failed."
+            exit 1
         }
-        $process = Start-Process @processOptions
+
+        $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
@@ -328,14 +327,13 @@ if (!(Get-Command git-lfs -ErrorAction SilentlyContinue)) {
 
         $tempOutFile = [System.IO.Path]::GetTempFileName() + ".out.json"
         $installGitLfsCommand = "Install-WinGetPackage -Source winget -Id GitHub.GitLFS | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
-        $processOptions = @{
-            FilePath = "C:\Program Files\PowerShell\7\pwsh.exe"
-            ArgumentList = "$($mtaFlag) -Command `"$($installGitLfsCommand)`""
-            PassThru = $true
-            NoNewWindow = $true
-            WorkingDirectory = $env:TEMP
+        $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"$($installGitLfsCommand)`""}
+        if (!($processCreation) -or !($processCreation.ProcessId)) {
+            Write-Error "Failed to install git-lfs package. Process creation failed."
+            exit 1
         }
-        $process = Start-Process @processOptions
+
+        $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()
         $installExitCode = $process.ExitCode

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -385,6 +385,7 @@ else {
         # read the output file and write it to the console
         if (Test-Path -Path $tempOutFile) {
             $unitResults = Get-Content -Path $tempOutFile -Raw | Out-String
+            Write-Host $unitResults
             Remove-Item -Path $tempOutFile -Force
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -338,23 +338,8 @@ else {
     $tempOutFile = [System.IO.Path]::GetTempFileName() + ".out.json"
 
     $mtaFlag = "-MTA"
-    $scopeFlag = ""
-    $sourceFlag = "-Source winget"
-    $packagesThatRequireSystemScopeUnderSystemAccount = @(
-        "microsoft.visualstudiocode",
-        "microsoft.visualstudiocode.cli",
-        "microsoft.visualstudiocodeinsiders",
-        "microsoft.visualstudiocodeinsiders.cli",
-        "microsoft.powertoys"
-    )
-    if ($packagesThatRequireSystemScopeUnderSystemAccount -contains ($Package.ToLowerInvariant())) {
-        $scopeFlag = "-Scope SystemOrUnknown"
-    }
-
     if ($PsInstallScope -eq "CurrentUser") {
         $mtaFlag = ""
-        $scopeFlag = ""
-        $sourceFlag = ""
     }
 
     # We're running in package mode:
@@ -366,7 +351,7 @@ else {
             $versionFlag = "-Version '$($Version)'"
         }
 
-        $installPackageCommand = "Install-WinGetPackage $($scopeFlag) $($sourceFlag) -Id '$($Package)' $($versionFlag) | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
+        $installPackageCommand = "Install-WinGetPackage -Scope SystemOrUnknown -Source winget -Id '$($Package)' $($versionFlag) | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
         $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe $($mtaFlag) -Command `"$($installPackageCommand)`""}
         if (!($processCreation) -or !($processCreation.ProcessId)) {
             Write-Error "Failed to install package. Process creation failed."

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -338,8 +338,22 @@ else {
     $tempOutFile = [System.IO.Path]::GetTempFileName() + ".out.json"
 
     $mtaFlag = "-MTA"
+    $scopeFlag = ""
+    $sourceFlag = "-Source winget"
+    $packagesThatRequireSystemScopeUnderSystemAccount = @(
+        "microsoft.visualstudiocode",
+        "microsoft.visualstudiocode.cli",
+        "microsoft.visualstudiocodeinsiders",
+        "microsoft.visualstudiocodeinsiders.cli",
+        "microsoft.powertoys"
+    )
     if ($PsInstallScope -eq "CurrentUser") {
         $mtaFlag = ""
+        $scopeFlag = ""
+        $sourceFlag = ""
+    }
+    elseif ($packagesThatRequireSystemScopeUnderSystemAccount -contains ($Package.ToLowerInvariant())) {
+        $scopeFlag = "-Scope SystemOrUnknown"
     }
 
     # We're running in package mode:
@@ -351,20 +365,20 @@ else {
             $versionFlag = "-Version '$($Version)'"
         }
 
-        $installPackageCommand = "Install-WinGetPackage -scope SystemOrUnknown -Source winget -Id '$($Package)' $($versionFlag) | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
+        $installPackageCommand = "Install-WinGetPackage $($scopeFlag) $($sourceFlag) -Id '$($Package)' $($versionFlag) | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
         $processOptions = @{
-           FilePath = "C:\Program Files\PowerShell\7\pwsh.exe"
-           ArgumentList = "$($mtaFlag) -Command `"$($installPackageCommand)`""
-           PassThru = $true
-           NoNewWindow = $true
-           WorkingDirectory = $env:TEMP
+            FilePath = "C:\Program Files\PowerShell\7\pwsh.exe"
+            ArgumentList = "$($mtaFlag) -Command `"$($installPackageCommand)`""
+            PassThru = $true
+            NoNewWindow = $true
+            WorkingDirectory = $env:TEMP
         }
         $process = Start-Process @processOptions
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
         if ($installExitCode -ne 0) {
-            Write-Error "Failed to install package. Exit code: $installExitCode"
+            Write-Error "Failed to install package. Exit code: $($installExitCode)."
             exit 1
         }
 
@@ -375,12 +389,12 @@ else {
             # If there are any errors in the package installation, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json
             if ($unitResultsObject.Status -ne "Ok") {
-                Write-Error "There were errors installing the package"
+                Write-Error "There were errors installing the package."
                 exit 1
             }
         }
         else {
-            Write-Host "Couldn't find output file for package installation, assuming fail"
+            Write-Host "Couldn't find output file for package installation, assuming fail."
             exit 1
         }
     }
@@ -388,55 +402,36 @@ else {
     elseif ($ConfigurationFile) {
         Write-Host "Running installation of configuration file: $($ConfigurationFile)"
         $applyConfigCommand = "Get-WinGetConfiguration -File '$($ConfigurationFile)' | Invoke-WinGetConfiguration -AcceptConfigurationAgreements | Select-Object -ExpandProperty UnitResults | ConvertTo-Json -Depth 10 | Tee-Object -FilePath '$($tempOutFile)'"
-        # Method A: try to run pwsh directly:
-        #Write-Host "pwsh -Command `"$($applyConfigCommand)`""
-        #pwsh.exe -Command "`"$($applyConfigCommand)`""
-        #$installExitCode = $LASTEXITCODE
-        #
-        # Method B: try to run pwsh via Start-Process:
-        #Write-Host "C:\Program Files\PowerShell\7\pwsh.exe -Command `"$($applyConfigCommand)`""
-        #$processOptions = @{
-        #    FilePath = "C:\Program Files\PowerShell\7\pwsh.exe"
-        #    ArgumentList = "-Command `"$($applyConfigCommand)`""
-        #    PassThru = $true
-        #    NoNewWindow = $true
-        #    WorkingDirectory = $env:TEMP
-        #}
-        #$process = Start-Process @processOptions
-        #$handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
-        #$process.WaitForExit()
-        #$installExitCode = $process.ExitCode
-        #
-        # Both methods A and B fail to run the command in the provisioning context with a timeout error,
-        # meaning that the process is not being created correctly, causing the customization task to fail
-        # after 1200 seconds.
-        # Method C: try to run pwsh via Invoke-CimMethod:
         $processCreation = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="C:\Program Files\PowerShell\7\pwsh.exe -Command `"$($applyConfigCommand)`""}
+        if (!($processCreation) -or !($processCreation.ProcessId)) {
+            Write-Error "Failed to run configuration file installation. Process creation failed."
+            exit 1
+        }
+
         $process = Get-Process -Id $processCreation.ProcessId
         $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
         if ($installExitCode -ne 0) {
-            Write-Error "Failed to install packages. Exit code: $installExitCode"
+            Write-Error "Failed to run configuration file installation. Exit code: $($installExitCode)."
             exit 1
         }
 
         # read the output file and write it to the console
         if (Test-Path -Path $tempOutFile) {
             $unitResults = Get-Content -Path $tempOutFile -Raw | Out-String
+            Write-Host $unitResults
             Remove-Item -Path $tempOutFile -Force
             # If there are any errors in the unit results, we need to exit with a non-zero code
             $unitResultsObject = $unitResults | ConvertFrom-Json
             $errors = $unitResultsObject | Where-Object { $_.ResultCode -ne "0" }
             if ($errors) {
-                Write-Error "There were errors applying the configuration"
+                Write-Error "There were errors applying the configuration."
                 exit 1
             }
-
-            Write-Host $unitResults # this line is only needed if using the Invoke-CimMethod functionality above, remove otherwise
         }
         else {
-            Write-Host "Couldn't find output file for configuration application, assuming fail"
+            Write-Host "Couldn't find output file for configuration application, assuming fail."
             exit 1
         }
     }


### PR DESCRIPTION
Moving away from Invoke-CimMethod caused instability for customers and we decided to roll back to using Invoke-CimMethod to spin up pwsh in winget scenarios. We will work on an alternative solution for organizations that cannot run Invoke-CimMethod in their powershell scripts.