### PR TITLE
Bug fix: Ensure we install visual C++ when dependency is missing

### DIFF
--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -187,15 +187,17 @@ function InstallWinGet {
     if ($PsInstallScope -eq "CurrentUser") {
         # Under a user account, the way to materialize winget.exe and make it work is by installing DesktopAppInstaller appx,
         # which in turn may have Xaml and VC++ redistributable requirements.
+        
+        $architecture = "x64"
+        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $architecture = "arm64"
+        }
+
         $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
         if (!($msVCLibsPackage)) {
         # Install Microsoft.VCLibs.140.00.UWPDesktop
             try {
                 Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
-                $architecture = "x64"
-                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-                    $architecture = "arm64"
-                }
                 $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
                 $MsVCLibsAppx = "$($MsVCLibs).appx"
 
@@ -213,10 +215,6 @@ function InstallWinGet {
             # install Microsoft.UI.Xaml
             try {
                 Write-Host "Installing Microsoft.UI.Xaml"
-                $architecture = "x64"
-                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-                    $architecture = "arm64"
-                }
                 $MsUiXaml = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.UI.Xaml.2.8.6"
                 $MsUiXamlZip = "$($MsUiXaml).zip"
                 Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6" -OutFile $MsUiXamlZip

--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -187,6 +187,27 @@ function InstallWinGet {
     if ($PsInstallScope -eq "CurrentUser") {
         # Under a user account, the way to materialize winget.exe and make it work is by installing DesktopAppInstaller appx,
         # which in turn may have Xaml and VC++ redistributable requirements.
+        $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
+        if (!($msVCLibsPackage)) {
+        # Install Microsoft.VCLibs.140.00.UWPDesktop
+            try {
+                Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
+                $architecture = "x64"
+                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+                    $architecture = "arm64"
+                }
+                $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
+                $MsVCLibsAppx = "$($MsVCLibs).appx"
+
+                Invoke-WebRequest -Uri "https://aka.ms/Microsoft.VCLibs.$($architecture).14.00.Desktop.appx" -OutFile $MsVCLibsAppx
+                Add-AppxPackage -Path $MsVCLibsAppx -ForceApplicationShutdown
+                Write-Host "Done Installing Microsoft.VCLibs.140.00.UWPDesktop"
+            } catch {
+                Write-Host "Failed to install Microsoft.VCLibs.140.00.UWPDesktop"
+                Write-Error $_
+            }
+        }
+
         $msUiXamlPackage = Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8" | Where-Object { $_.Version -ge "8.2310.30001.0" }
         if (!($msUiXamlPackage)) {
             # install Microsoft.UI.Xaml

--- a/Tasks/git-clone/runAsUser.ps1
+++ b/Tasks/git-clone/runAsUser.ps1
@@ -53,15 +53,16 @@ else {
     Write-Host "Microsoft.WinGet.Configuration is already installed"
 }
 
+$architecture = "x64"
+if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+    $architecture = "arm64"
+}
+
 $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.33728.0" }
 if (!($msVCLibsPackage)) {
 # Install Microsoft.VCLibs.140.00.UWPDesktop
     try {
         Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
-        $architecture = "x64"
-        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-            $architecture = "arm64"
-        }
         $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
         $MsVCLibsAppx = "$($MsVCLibs).appx"
 
@@ -79,10 +80,6 @@ if (!($msUiXamlPackage)) {
     # install Microsoft.UI.Xaml
     try{
         Write-Host "Installing Microsoft.UI.Xaml"
-        $architecture = "x64"
-        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-            $architecture = "arm64"
-        }
         $MsUiXaml = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.UI.Xaml.2.8.6"
         $MsUiXamlZip = "$($MsUiXaml).zip"
         Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6" -OutFile $MsUiXamlZip

--- a/Tasks/git-clone/runAsUser.ps1
+++ b/Tasks/git-clone/runAsUser.ps1
@@ -53,6 +53,27 @@ else {
     Write-Host "Microsoft.WinGet.Configuration is already installed"
 }
 
+$msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.33728.0" }
+if (!($msVCLibsPackage)) {
+# Install Microsoft.VCLibs.140.00.UWPDesktop
+    try {
+        Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
+        $architecture = "x64"
+        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $architecture = "arm64"
+        }
+        $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
+        $MsVCLibsAppx = "$($MsVCLibs).appx"
+
+        Invoke-WebRequest -Uri "https://aka.ms/Microsoft.VCLibs.$($architecture).14.00.Desktop.appx" -OutFile $MsVCLibsAppx
+        Add-AppxPackage -Path $MsVCLibsAppx -ForceApplicationShutdown
+        Write-Host "Done Installing Microsoft.VCLibs.140.00.UWPDesktop"
+    } catch {
+        Write-Host "Failed to install Microsoft.VCLibs.140.00.UWPDesktop"
+        Write-Error $_
+    }
+}
+
 $msUiXamlPackage = Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8" | Where-Object { $_.Version -ge "8.2310.30001.0" }
 if (!($msUiXamlPackage)) {
     # install Microsoft.UI.Xaml

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -197,15 +197,16 @@ function InstallWinGet {
 
     if ($PsInstallScope -eq "CurrentUser") {
 
+        $architecture = "x64"
+        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $architecture = "arm64"
+        }
+
         $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
         if (!($msVCLibsPackage)) {
         # Install Microsoft.VCLibs.140.00.UWPDesktop
             try {
                 Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
-                $architecture = "x64"
-                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-                    $architecture = "arm64"
-                }
                 $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
                 $MsVCLibsAppx = "$($MsVCLibs).appx"
     
@@ -217,16 +218,12 @@ function InstallWinGet {
                 Write-Error $_
             }
         }
-        
+
         $msUiXamlPackage = Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8" | Where-Object { $_.Version -ge "8.2310.30001.0" }
         if (!($msUiXamlPackage)) {
             # instal Microsoft.UI.Xaml
             try {
                 Write-Host "Installing Microsoft.UI.Xaml"
-                $architecture = "x64"
-                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-                    $architecture = "arm64"
-                }
                 $MsUiXaml = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.UI.Xaml.2.8.6"
                 $MsUiXamlZip = "$($MsUiXaml).zip"
                 Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6" -OutFile $MsUiXamlZip

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -196,6 +196,28 @@ function InstallWinGet {
     }
 
     if ($PsInstallScope -eq "CurrentUser") {
+
+        $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
+        if (!($msVCLibsPackage)) {
+        # Install Microsoft.VCLibs.140.00.UWPDesktop
+            try {
+                Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
+                $architecture = "x64"
+                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+                    $architecture = "arm64"
+                }
+                $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
+                $MsVCLibsAppx = "$($MsVCLibs).appx"
+    
+                Invoke-WebRequest -Uri "https://aka.ms/Microsoft.VCLibs.$($architecture).14.00.Desktop.appx" -OutFile $MsVCLibsAppx
+                Add-AppxPackage -Path $MsVCLibsAppx -ForceApplicationShutdown
+                Write-Host "Done Installing Microsoft.VCLibs.140.00.UWPDesktop"
+            } catch {
+                Write-Host "Failed to install Microsoft.VCLibs.140.00.UWPDesktop"
+                Write-Error $_
+            }
+        }
+        
         $msUiXamlPackage = Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8" | Where-Object { $_.Version -ge "8.2310.30001.0" }
         if (!($msUiXamlPackage)) {
             # instal Microsoft.UI.Xaml

--- a/Tasks/winget/runAsUser.ps1
+++ b/Tasks/winget/runAsUser.ps1
@@ -54,15 +54,16 @@ else {
     Write-Host "Microsoft.WinGet.Configuration is already installed"
 }
 
+$architecture = "x64"
+if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+    $architecture = "arm64"
+}
+
 $msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
 if (!($msVCLibsPackage)) {
 # Install Microsoft.VCLibs.140.00.UWPDesktop
     try {
         Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
-        $architecture = "x64"
-        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-            $architecture = "arm64"
-        }
         $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
         $MsVCLibsAppx = "$($MsVCLibs).appx"
 
@@ -80,10 +81,6 @@ if (!($msUiXamlPackage)) {
     # instal Microsoft.UI.Xaml
     try{
         Write-Host "Installing Microsoft.UI.Xaml"
-        $architecture = "x64"
-        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-            $architecture = "arm64"
-        }
         $MsUiXaml = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.UI.Xaml.2.8.6"
         $MsUiXamlZip = "$($MsUiXaml).zip"
         Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6" -OutFile $MsUiXamlZip

--- a/Tasks/winget/runAsUser.ps1
+++ b/Tasks/winget/runAsUser.ps1
@@ -54,6 +54,27 @@ else {
     Write-Host "Microsoft.WinGet.Configuration is already installed"
 }
 
+$msVCLibsPackage = Get-AppxPackage -Name "Microsoft.VCLibs.140.00.UWPDesktop" | Where-Object { $_.Version -ge "14.0.30035.0" }
+if (!($msVCLibsPackage)) {
+# Install Microsoft.VCLibs.140.00.UWPDesktop
+    try {
+        Write-Host "Installing Microsoft.VCLibs.140.00.UWPDesktop"
+        $architecture = "x64"
+        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $architecture = "arm64"
+        }
+        $MsVCLibs = "$env:TEMP\$([System.IO.Path]::GetRandomFileName())-Microsoft.VCLibs.140.00.UWPDesktop"
+        $MsVCLibsAppx = "$($MsVCLibs).appx"
+
+        Invoke-WebRequest -Uri "https://aka.ms/Microsoft.VCLibs.$($architecture).14.00.Desktop.appx" -OutFile $MsVCLibsAppx
+        Add-AppxPackage -Path $MsVCLibsAppx -ForceApplicationShutdown
+        Write-Host "Done Installing Microsoft.VCLibs.140.00.UWPDesktop"
+    } catch {
+        Write-Host "Failed to install Microsoft.VCLibs.140.00.UWPDesktop"
+        Write-Error $_
+    }
+}
+
 $msUiXamlPackage = Get-AppxPackage -Name "Microsoft.UI.Xaml.2.8" | Where-Object { $_.Version -ge "8.2310.30001.0" }
 if (!($msUiXamlPackage)) {
     # instal Microsoft.UI.Xaml


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8ab23e49-98e9-48da-a082-790b79a5382b)

Winget succeeds when we ensure that VC++is installed:
![image](https://github.com/user-attachments/assets/f53d75d9-a81a-430b-82fb-56adef743547)

