### PR TITLE
winget and git-clone tasks: run winget install in silent mode

### DIFF
--- a/Tasks/git-clone/main.ps1
+++ b/Tasks/git-clone/main.ps1
@@ -266,9 +266,9 @@ function InstallPackage{
         # if winget is available, use it to install package
         if (Get-Command winget -ErrorAction SilentlyContinue) {
             Write-Host "Installing $PackageId with winget"
-            winget install --id $PackageId -e --source winget
+            winget install --id $PackageId -e --source winget --silent
             $installExitCode = $LASTEXITCODE
-            Write-Host "'winget install --id $PackageId -e --source winget' exited with code: $($installExitCode)"
+            Write-Host "'winget install --id $PackageId -e --source winget --silent' exited with code: $($installExitCode)"
             if ($installExitCode -eq 0) {
                 # add package path to path
                 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") + ";" + $PackagePath

--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -337,7 +337,7 @@ if ($RunAsUser -eq "true") {
             $versionFlag = "--version `"$($Version)`""
         }
         Write-Host "Appending package install: $($Package)"
-        AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) --accept-source-agreements --accept-package-agreements"
+        AppendToUserScript "winget install --id `"$($Package)`" $($versionFlag) --accept-source-agreements --accept-package-agreements --silent"
         AppendToUserScript "Write-Host `"winget exit code: `$LASTEXITCODE`""
     }
     # We're running in configuration file mode:


### PR DESCRIPTION
Customers have reported installers occasionally getting stuck due to interactive prompts. Proposed mitigation is to run winget install in [silent mode](https://github.com/MaxHorstmann/winget-cli/blob/master/src/PowerShell/Help/Microsoft.WinGet.Client/Install-WinGetPackage.md#-mode) (vs interactive mode).