### PR TITLE
Increase reliability of winget task

### DIFF
--- a/Tasks/winget/main.ps1
+++ b/Tasks/winget/main.ps1
@@ -385,8 +385,21 @@ else {
             $process.WaitForExit()
             $installExitCode = $process.ExitCode
             if ($installExitCode -ne 0) {
-                Write-Error "Failed to install package. Exit code: $($installExitCode)."
-                exit 1
+                if ($PsInstallScope -eq "CurrentUser") {
+                    # try executing the commandlet via Start-Process instead of using Invoke-CimMethod, as this works better in some cases
+                    $process = Start-Process -FilePath "C:\Program Files\PowerShell\7\pwsh.exe" -ArgumentList "-Command $($installPackageCommand)" -PassThru
+                    $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
+                    $process.WaitForExit()
+                    $installExitCode = $process.ExitCode
+                    if ($installExitCode -ne 0) {
+                        Write-Error "Failed to install package. Exit code: $($installExitCode)."
+                        exit 2
+                    }
+                }
+                else {
+                    Write-Error "Failed to install package. Exit code: $($installExitCode)."
+                    exit 1
+                }
             }
 
             # read the output file and write it to the console
@@ -430,8 +443,21 @@ else {
         $process.WaitForExit()
         $installExitCode = $process.ExitCode
         if ($installExitCode -ne 0) {
-            Write-Error "Failed to run configuration file installation. Exit code: $($installExitCode)."
-            exit 1
+            if ($PsInstallScope -eq "CurrentUser") {
+                # try executing the commandlet via Start-Process instead of using Invoke-CimMethod, as this works better in some cases
+                $process = Start-Process -FilePath "C:\Program Files\PowerShell\7\pwsh.exe" -ArgumentList "-Command $($applyConfigCommand)" -PassThru
+                $handle = $process.Handle # cache process.Handle so ExitCode isn't null when we need it below
+                $process.WaitForExit()
+                $installExitCode = $process.ExitCode
+                if ($installExitCode -ne 0) {
+                    Write-Error "Failed to run configuration file installation. Exit code: $($installExitCode)."
+                    exit 2
+                }
+            }
+            else {
+                Write-Error "Failed to run configuration file installation. Exit code: $($installExitCode)."
+                exit 1
+            }
         }
 
         # read the output file and write it to the console


### PR DESCRIPTION
This change adds a second try to install packages or apply configurations when Invoke-CimMethod doesn't work. This can happen in certain scenarios (for example, when machine policies reduce the context of what Invoke-CimMethod can do for security reasons), leading to user frustration. This change is an attempt to help make the winget task more likely to succeed installing packages in user context (not system) by doing a second attempt to run the installation or application command but using Start-Process instead of Invoke-CimMethod.